### PR TITLE
Update README.md - clone through https instead of git

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ easy to fork and contribute any changes back upstream.
 1. **Check out pyenv where you want it installed.**
    A good place to choose is `$HOME/.pyenv` (but you can install it somewhere else).
 
-        $ git clone git://github.com/yyuu/pyenv.git ~/.pyenv
+        $ git clone https://github.com/yyuu/pyenv.git ~/.pyenv
 
 
 2. **Define environment variable `PYENV_ROOT`** to point to the path where


### PR DESCRIPTION
git:// protocol is blocked by a lot of servers, https works fine.
